### PR TITLE
Force lower case hypermutation fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.swp
+phyml

--- a/removeHypermutatedSequences.R
+++ b/removeHypermutatedSequences.R
@@ -12,19 +12,18 @@ source( "removeDuplicateSequencesFromAlignedFasta_safetosource.R" )
 ## Returns the number of hypermutated (and therefore removed or fixed) sequences.
 removeHypermutatedSequences <- function ( fasta.file, output.dir = NULL, p.value.threshold = 0.1, fix.instead.of.remove = FALSE, fix.with = "R" ) {
 
-    fix.with <- tolower(fix.with)
-    if( length( grep( "^(.*?)\\/[^\\/]+$", fasta.file ) ) == 0 ) {
-        fasta.file.path <- ".";
-    } else {
-        fasta.file.path <-
-            gsub( "^(.*?)\\/[^\\/]+$", "\\1", fasta.file );
-    }
-    fasta.file.short <-
-        gsub( "^.*?\\/?([^\\/]+?)$", "\\1", fasta.file, perl = TRUE );
-    fasta.file.short.nosuffix <-
-        gsub( "^([^\\.]+)(\\..+)?$", "\\1", fasta.file.short, perl = TRUE );
-    fasta.file.short.suffix <-
-        gsub( "^([^\\.]+)(\\..+)?$", "\\2", fasta.file.short, perl = TRUE );
+  if( length( grep( "^(.*?)\\/[^\\/]+$", fasta.file ) ) == 0 ) {
+      fasta.file.path <- ".";
+  } else {
+      fasta.file.path <-
+          gsub( "^(.*?)\\/[^\\/]+$", "\\1", fasta.file );
+  }
+  fasta.file.short <-
+      gsub( "^.*?\\/?([^\\/]+?)$", "\\1", fasta.file, perl = TRUE );
+  fasta.file.short.nosuffix <-
+      gsub( "^([^\\.]+)(\\..+)?$", "\\1", fasta.file.short, perl = TRUE );
+  fasta.file.short.suffix <-
+      gsub( "^([^\\.]+)(\\..+)?$", "\\2", fasta.file.short, perl = TRUE );
 
   if( is.null( output.dir ) ) {
       output.dir = fasta.file.path;
@@ -35,6 +34,10 @@ removeHypermutatedSequences <- function ( fasta.file, output.dir = NULL, p.value
   ## Remove "/" from end of output.dir
   output.dir <-
       gsub( "^(.*?)\\/+$", "\\1", output.dir );
+
+  if( fix.instead.of.remove ){
+      fix.with <- tolower(fix.with)
+  }
   
   in.fasta <- read.dna( fasta.file, format = "fasta" );
 

--- a/removeHypermutatedSequences.R
+++ b/removeHypermutatedSequences.R
@@ -12,6 +12,7 @@ source( "removeDuplicateSequencesFromAlignedFasta_safetosource.R" )
 ## Returns the number of hypermutated (and therefore removed or fixed) sequences.
 removeHypermutatedSequences <- function ( fasta.file, output.dir = NULL, p.value.threshold = 0.1, fix.instead.of.remove = FALSE, fix.with = "R" ) {
 
+    fix.with <- tolower(fix.with)
     if( length( grep( "^(.*?)\\/[^\\/]+$", fasta.file ) ) == 0 ) {
         fasta.file.path <- ".";
     } else {


### PR DESCRIPTION
as.DNAbin makes upper case letters NA:

> as.character(x[2,1:6])
>                                               [,1] [,2] [,3] [,4] [,5] [,6]
> CAP200_3100_029wpi_c2a_c3b_run1_AAAAAATTGA_23 "t"  "c"  "t"  "t"  "t"  "t"
> 
> x[2,1] <- as.DNAbin('R')
> x[2,2] <- as.DNAbin('r')
> 
> as.character(x[2,1:6])
>                                               [,1] [,2] [,3] [,4] [,5] [,6]
> CAP200_3100_029wpi_c2a_c3b_run1_AAAAAATTGA_23 NA   "r"  "t"  "t"  "t"  "t"
